### PR TITLE
cmake: export and install library stag_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,10 @@ target_link_libraries(stag_node
 # INSTALL #
 ###########
 
+install(DIRECTORY include/
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+)
+
 install(FILES stag_nodelet.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ generate_messages(
 
 catkin_package(
   INCLUDE_DIRS include src/stag
-  LIBRARIES stag_ros
+  LIBRARIES stag_core
   CATKIN_DEPENDS camera_info_manager cv_bridge geometry_msgs image_transport message_generation message_runtime nodelet roscpp sensor_msgs std_msgs
 )
 
@@ -131,7 +131,9 @@ install(DIRECTORY cfg launch
 )
 
 install(TARGETS
+  stag_core
   stag_node
+  stag_nodelet
   stag_nodelet_runnable
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
Thanks for your nice package, or more specifically for porting [STag](https://github.com/bbenligiray/stag) and integrating it with ROS!

Some suggested changes to `CMakeLists.txt`:

- List library `stag_core` in `catkin_package(LIBRARIES ...)`, such that other derived packages can link to it. A library named `stag_ros` is not built nor installed by this package, so trying to
  ```cmake
  find_package(catkin REQUIRED COMPONENTS stag_ros)
  ```
  as-is would trigger a "library not found" error in catkin. See [here](https://docs.ros.org/en/api/catkin/html/dev_guide/generated_cmake_api.html#catkin-package) for the official documentation.

  _Background:_ We are integrating the STag in another package built with catkin. So starting from `stag_ros` is convenient, but we would like to link to library `stag_core` only, and not use the nodelets or node executables as-is.

- All library targets need to be installed for the package to work with an install-space, not only the executables. Unless the libraries would be linked statically, but that is not the default with catkin.

  If not, running `stag_node` throws an error:
  ```
  $ source /path/to/install/setup.bash
  $ rosrun stag_ros stag_node             
  /path/to/install/lib/stag_ros/stag_node: error while loading shared libraries: libstag_core.so: cannot open shared object file: No such file or directory
  ```

  It may still work without, as long as the devel-space is around and has not been cleaned, but not for a binary package built by the OSRF buildfarm, for example.

- _Edit (after https://github.com/usrl-uofsc/stag_ros/pull/18/commits/13aa45ee22606a13b8a1d5b87b908146a29966eb):_ Also the header files need to be installed.

If you prefer not to export any library target and/or header file to downstream packages, that is also fine. Then we can fork [STag](https://github.com/bbenligiray/stag) directly and add a `package.xml` and `CMakeLists.txt` file there. I would still recommend to leave the `catkin_package()` call empty then, because there is nothing to export, and for simply running the nodes or nodelets that is not required.