### PR TITLE
Fix more mismatched delete operators (cherry-pick from upstream stag)

### DIFF
--- a/include/stag/ED/EDLines.h
+++ b/include/stag/ED/EDLines.h
@@ -51,9 +51,9 @@ struct EDLines {
 
   /// Destructor
   ~EDLines() {
-    delete lines;
-    delete x;
-    delete y;
+    delete[] lines;
+    delete[] x;
+    delete[] y;
   }  // end-EDLines
 
   /// clear
@@ -63,7 +63,7 @@ struct EDLines {
     capacity *= 2;
     LineSegment *newArr = new LineSegment[capacity];
     memcpy(newArr, lines, sizeof(LineSegment) * noLines);
-    delete lines;
+    delete[] lines;
     lines = newArr;
   }  // end-expandCapacity
 

--- a/include/stag/ED/EdgeMap.h
+++ b/include/stag/ED/EdgeMap.h
@@ -42,9 +42,9 @@ struct EdgeMap {
 
   // Destructor
   ~EdgeMap() {
-    delete edgeImg;
-    delete pixels;
-    delete segments;
+    delete[] edgeImg;
+    delete[] pixels;
+    delete[] segments;
   }  // end-~EdgeMap
 
   void ConvertEdgeSegments2EdgeImg() {

--- a/include/stag/ED/NFA.h
+++ b/include/stag/ED/NFA.h
@@ -17,7 +17,9 @@ struct NFALUT {
   NFALUT(int size, double prob, double logNT);
 
   // Destructor
-  ~NFALUT() { delete LUT; }  // end-~NFALUT
+  ~NFALUT() {
+    delete[] LUT;
+  }  // end-~NFALUT
 };
 
 ///-------------------------------------------

--- a/include/stag/EDInterface.h
+++ b/include/stag/EDInterface.h
@@ -11,6 +11,11 @@ class EDInterface {
   EDLines* edLines = NULL;
 
  public:
+
+  ~EDInterface() {
+    delete edgeMap;
+    delete edLines;
+  }
   // runs EDPF and EDLines, keeps the results in memory
   void runEDPFandEDLines(const cv::Mat& image);
 

--- a/src/stag/ED/ED.cpp
+++ b/src/stag/ED/ED.cpp
@@ -67,9 +67,9 @@
 //                                    GRADIENT_THRESH, ANCHOR_THRESH);
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothImg;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothImg;
 
 //   return map;
 // }  // DetectEdgesByED
@@ -131,9 +131,9 @@
 // #endif
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothImg;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothImg;
 
 //   return map;
 // }  // DetectEdgesByEDV
@@ -277,9 +277,9 @@ EdgeMap *DetectEdgesByEDPF(unsigned char *srcImg, int width, int height,
 //                                           int MIN_PATH_LEN);
 //   JoinAnchorPointsUsingSortedAnchors(gradImg, dirImg, map, 1, 10);
 
-//   delete smoothImg;
-//   delete gradImg;
-//   delete dirImg;
+//   delete[] smoothImg;
+//   delete[] gradImg;
+//   delete[] dirImg;
 
 //   cvReleaseImage(&iplImg);
 //   cvReleaseImage(&edgeImg);
@@ -347,7 +347,7 @@ EdgeMap *DetectEdgesByEDPF(unsigned char *srcImg, int width, int height,
 //   cvReleaseImage(&iplImg);
 //   cvReleaseImage(&edgeImg);
 
-//   delete gradImg;
+//   delete[] gradImg;
 
 //   return map;
 // }  // end-DetectEdgesByCannySR2
@@ -368,7 +368,7 @@ EdgeMap *DetectEdgesByEDPF(unsigned char *srcImg, int width, int height,
 //   ValidateEdgeSegments(map, smoothImg, 2.25);  // With Prewitt
 //   //  ValidateEdgeSegments2(map, smoothImg, 2);  // With LSD
 
-//   delete smoothImg;
+//   delete[] smoothImg;
 
 //   return map;
 // }  // end-DetectEdgesByCannySRPF
@@ -454,11 +454,11 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 //   //  not give good response.
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothCh3Img;
-//   delete smoothCh2Img;
-//   delete smoothCh1Img;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothCh3Img;
+//   delete[] smoothCh2Img;
+//   delete[] smoothCh1Img;
 
 //   return map;
 // }  // end-DetectEdgesByED
@@ -545,11 +545,11 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 // #endif
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothCh3Img;
-//   delete smoothCh2Img;
-//   delete smoothCh1Img;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothCh3Img;
+//   delete[] smoothCh2Img;
+//   delete[] smoothCh1Img;
 
 //   return map;
 // }  // end-DetectEdgesByEDPF
@@ -589,7 +589,7 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 //     }  // end-for
 //   }    // end-for
 
-//   delete smoothContourImg;
+//   delete[] smoothContourImg;
 
 // #if 0
 //   memset(smoothImg, 0, width*height);
@@ -602,9 +602,9 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 //                                    GRADIENT_THRESH, ANCHOR_THRESH);
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothImg;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothImg;
 
 //   return map;
 // }  // end-DetectContourEdgeMapByED1
@@ -657,18 +657,18 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 //     }  // end-for
 //   }    // end-for
 
-//   delete smoothContourImg;
+//   delete[] smoothContourImg;
 
 //   // Now, detect the edges by ED
 //   EdgeMap *map = DoDetectEdgesByED(gradImg, dirImg, width, height,
 //                                    GRADIENT_THRESH, ANCHOR_THRESH);
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothCh3Img;
-//   delete smoothCh2Img;
-//   delete smoothCh1Img;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothCh3Img;
+//   delete[] smoothCh2Img;
+//   delete[] smoothCh1Img;
 
 //   return map;
 // }  // end-DetectContourEdgeMapByED1
@@ -695,7 +695,7 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 //     }  // end-for
 //   }    // end-for
 
-//   delete smoothImg;
+//   delete[] smoothImg;
 
 // #if 0
 //   DumpGradImage("OutputImages/gradImg.pgm", gradImg, width, height);
@@ -705,7 +705,7 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 //   EdgeMap *map = DoDetectEdgesByED(gradImg, width, height, 4);
 
 //   // Clean up
-//   delete gradImg;
+//   delete[] gradImg;
 
 //   return map;
 // }  // end-DetectContourEdgeMapByED2
@@ -775,10 +775,10 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 //   JoinAnchorPointsUsingSortedAnchors(gradImg, dirImg, map, 1, 10);
 
 //   // Clean up
-//   delete smoothImg;
-//   delete smoothContourImg;
-//   delete gradImg;
-//   delete dirImg;
+//   delete[] smoothImg;
+//   delete[] smoothContourImg;
+//   delete[] gradImg;
+//   delete[] dirImg;
 
 //   return map;
 // }  // end-DetectContourEdgeMapByED3
@@ -962,13 +962,13 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 // #endif
 
 //   // Clean up
-//   delete gradImg;
-//   delete gxImg;
-//   delete gyImg;
-//   delete dirImg;
-//   delete smoothCh1Img;
-//   delete smoothCh2Img;
-//   delete smoothCh3Img;
+//   delete[] gradImg;
+//   delete[] gxImg;
+//   delete[] gyImg;
+//   delete[] dirImg;
+//   delete[] smoothCh1Img;
+//   delete[] smoothCh2Img;
+//   delete[] smoothCh3Img;
 
 //   return map;
 // }  // end-DetectContourEdgeMapByED3
@@ -1018,9 +1018,9 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 // #endif
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothImg;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothImg;
 
 //   return map;
 // }  // DetectEdgesByED10
@@ -1103,11 +1103,11 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 // #endif
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothCh3Img;
-//   delete smoothCh2Img;
-//   delete smoothCh1Img;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothCh3Img;
+//   delete[] smoothCh2Img;
+//   delete[] smoothCh1Img;
 
 //   return map;
 // }  // end-DetectEdgesByED10
@@ -1211,11 +1211,11 @@ static void ScaleImage(unsigned char *srcImg, int width, int height) {
 // #endif
 
 //   // Clean up
-//   delete gradImg;
-//   delete dirImg;
-//   delete smoothCh3Img;
-//   delete smoothCh2Img;
-//   delete smoothCh1Img;
+//   delete[] gradImg;
+//   delete[] dirImg;
+//   delete[] smoothCh3Img;
+//   delete[] smoothCh2Img;
+//   delete[] smoothCh1Img;
 
 //   return map;
 // }  // end-DetectEdgesByED10V

--- a/src/stag/ED/EDInternals.cpp
+++ b/src/stag/ED/EDInternals.cpp
@@ -1449,7 +1449,7 @@ void JoinAnchorPointsUsingSortedAnchors(short *gradImg, unsigned char *dirImg,
 
   map->noSegments = noSegments;
 
-  delete A;
+  delete[] A;
   delete[] chains;
   delete[] stack;
   delete[] pixels;

--- a/src/stag/ED/EDInternals.cpp
+++ b/src/stag/ED/EDInternals.cpp
@@ -837,10 +837,10 @@ static int RetrieveChainNos(Chain *chains, int root, int chainNos[]) {
 
 //   map->noSegments = noSegments;
 
-//   delete chains;
-//   delete stack;
-//   delete pixels;
-//   delete chainNos;
+//   delete[] chains;
+//   delete[] stack;
+//   delete[] pixels;
+//   delete[] chainNos;
 // }  // end-JoinAnchorPoints
 
 ///-----------------------------------------------------------------------------------
@@ -2594,11 +2594,11 @@ void JoinAnchorPointsUsingSortedAnchors(short *gradImg, unsigned char *dirImg,
 
 //   map->noSegments = noSegments;
 
-//   delete A;
-//   delete chains;
-//   delete stack;
-//   delete pixels;
-//   delete chainNos;
+//   delete[] A;
+//   delete[] chains;
+//   delete[] stack;
+//   delete[] pixels;
+//   delete[] chainNos;
 // }  // end-JoinAnchorPointsUsingSortedAnchors4Dirs
 
 ///----------------------------------------------------------------------------------------------
@@ -3375,8 +3375,8 @@ EdgeMap *DoDetectEdgesByED(short *gradImg, unsigned char *dirImg, int width,
 
 //   map->noSegments = noSegments;
 
-//   delete tmpPixels;
-//   delete A;
+//   delete[] tmpPixels;
+//   delete[] A;
 // }  // end-JoinAnchorPointsUsingSortedAnchors
 
 // ///----------------------------------------------------------------------------------------------

--- a/src/stag/ED/ValidateEdgeSegments.cpp
+++ b/src/stag/ED/ValidateEdgeSegments.cpp
@@ -53,7 +53,7 @@
 //   for (int i = 0; i < maxGradValue; i++)
 //     H[i] = (double)grads[i] / ((double)size);
 
-//   delete grads;
+//   delete[] grads;
 //   return gradImg;
 // }  // end-ComputeLSD
 
@@ -512,7 +512,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   for (int i = 0; i < maxGradValue; i++)
 //     H[i] = (double)grads[i] / ((double)size);
 
-//   delete grads;
+//   delete[] grads;
 
 //   // Compute np: # of segment pieces
 // #if 1
@@ -546,8 +546,8 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   /// Extract the new edge segments after validation
 //   ExtractNewSegments(map);
 
-//   delete H;
-//   delete gradImg;
+//   delete[] H;
+//   delete[] gradImg;
 // }  // end-ValidateEdgeSegments2
 
 ///--------------------------------------------------------------------------------------------------------------------
@@ -606,8 +606,8 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //     }    // end-for
 //   }      // end-for
 
-//   delete H;
-//   delete gradImg;
+//   delete[] H;
+//   delete[] gradImg;
 
 //   return noMaps;
 // }  // end-for
@@ -695,7 +695,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   for (int i = 0; i < maxGradValue; i++)
 //     H[i] = (double)grads[i] / ((double)size);
 
-//   delete grads;
+//   delete[] grads;
 
 //   // Compute np: # of segment pieces
 // #if 1
@@ -729,8 +729,8 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   /// Extract the new edge segments after validation
 //   ExtractNewSegments(map);
 
-//   delete H;
-//   delete gradImg;
+//   delete[] H;
+//   delete[] gradImg;
 // }  // end-ValidateEdgeSegments
 
 // ///--------------------------------------------------------------------------------------------------------------------
@@ -849,7 +849,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   for (int i = 0; i < maxGradValue; i++)
 //     H[i] = (double)grads[i] / ((double)size);
 
-//   delete grads;
+//   delete[] grads;
 
 //   // Compute np: # of segment pieces
 // #if 1
@@ -883,8 +883,8 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   /// Extract the new edge segments after validation
 //   ExtractNewSegments(map);
 
-//   delete H;
-//   delete gradImg;
+//   delete[] H;
+//   delete[] gradImg;
 // }  // end-ValidateEdgeSegments2
 
 // ///--------------------------------------------------------------------------------------------------------------------
@@ -1008,7 +1008,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   for (int i = 0; i < maxGradValue; i++)
 //     H[i] = (double)grads[i] / ((double)size);
 
-//   delete grads;
+//   delete[] grads;
 
 //   // Validate for different div values
 //   int index = 0;
@@ -1051,8 +1051,8 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //     }    // end-for
 //   }      // end-for
 
-//   delete H;
-//   delete gradImg;
+//   delete[] H;
+//   delete[] gradImg;
 
 //   return noMaps;
 // }  // end-ValidateEdgeSegmentsMultipleDiv
@@ -1089,7 +1089,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   for (int i = 0; i < maxGradValue; i++)
 //     H[i] = (double)grads[i] / ((double)size);
 
-//   delete grads;
+//   delete[] grads;
 
 //   // Compute np: # of segment pieces
 //   int np = 0;
@@ -1107,7 +1107,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   /// Extract the new edge segments after validation
 //   ExtractNewSegments(map);
 
-//   delete H;
+//   delete[] H;
 // }  // end-ValidateEdgeSegmentsWithGradientMap
 
 // ///----------------------------------------------------------------------------------
@@ -1143,7 +1143,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //   for (int i = 0; i < maxGradValue; i++)
 //     H[i] = (double)grads[i] / ((double)size);
 
-//   delete grads;
+//   delete[] grads;
 
 //   // Validate for different div values
 //   int index = 0;
@@ -1186,7 +1186,7 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
 //     }    // end-for
 //   }      // end-for
 
-//   delete H;
+//   delete[] H;
 
 //   return noMaps;
 // }  // end-ValidateEdgeSegmentsWithGradientMapMultipleDiv

--- a/src/stag/Ellipse.cpp
+++ b/src/stag/Ellipse.cpp
@@ -76,8 +76,8 @@ void jacobi(double **a, int n, double d[], double **v, int nrot) {
       for (iq = ip + 1; iq <= n; iq++) sm += fabs(a[ip][iq]);
     }
     if (sm == 0.0) {
-      delete b;
-      delete z;
+      delete[] b;
+      delete[] z;
       return;
     }
     if (i < 4)
@@ -134,8 +134,8 @@ void jacobi(double **a, int n, double d[], double **v, int nrot) {
     }
   }
   // printf("Too many iterations in routine JACOBI");
-  delete b;
-  delete z;
+  delete[] b;
+  delete[] z;
 }
 
 ///-----------------------------------------------------------
@@ -172,7 +172,7 @@ void choldc(double **a, int n, double **l) {
     }
   }
 
-  delete p;
+  delete[] p;
 }
 
 int inverse(double **TB, double **InvB, int N) {
@@ -467,7 +467,7 @@ customEllipse::customEllipse(pix *points, int noPnts) {
   DeallocateMatrix(L, 7);
   DeallocateMatrix(C, 7);
   DeallocateMatrix(invL, 7);
-  delete d;
+  delete[] d;
   DeallocateMatrix(V, 7);
   DeallocateMatrix(sol, 7);
 }
@@ -649,7 +649,7 @@ customEllipse::customEllipse(double *pX, double *pY, int noPnts) {
   DeallocateMatrix(L, 7);
   DeallocateMatrix(C, 7);
   DeallocateMatrix(invL, 7);
-  delete d;
+  delete[] d;
   DeallocateMatrix(V, 7);
   DeallocateMatrix(sol, 7);
 }
@@ -886,7 +886,7 @@ pix *customEllipse::DrawEllipse(int resolution) {
   DeallocateMatrix(Xneg, 3);
   DeallocateMatrix(ss1, 3);
   DeallocateMatrix(ss2, 3);
-  delete lambda;
+  delete[] lambda;
   DeallocateMatrix(uAiu, 3);
   DeallocateMatrix(A, 3);
   DeallocateMatrix(Ai, 3);

--- a/src/stag/Ellipse.cpp
+++ b/src/stag/Ellipse.cpp
@@ -652,6 +652,7 @@ customEllipse::customEllipse(double *pX, double *pY, int noPnts) {
   delete[] d;
   DeallocateMatrix(V, 7);
   DeallocateMatrix(sol, 7);
+  free(fitPoints);
 }
 
 customEllipse::customEllipse(double coefs[6]) {


### PR DESCRIPTION
I missed that one in #19 and you were too fast with merging it ;-)

It is a bit more hidden, because `A` is allocated within `SortAnchorsByGradValue()` here, and the compiler (Clang) does not emit a warning:

https://github.com/usrl-uofsc/stag_ros/blob/6e6c02158d72c4bdcf82f63d85031264dd635822/src/stag/ED/EDInternals.cpp#L178

https://github.com/usrl-uofsc/stag_ros/blob/6e6c02158d72c4bdcf82f63d85031264dd635822/src/stag/ED/EDInternals.cpp#L866

