### PR TITLE
Return the id and shift of the code with the minimum bit error

### DIFF
--- a/src/stag/Decoder.cpp
+++ b/src/stag/Decoder.cpp
@@ -1,5 +1,6 @@
 #include "stag/Decoder.h"
 
+#include <climits>
 #include <stdexcept>
 #include <fstream>
 #include <string>
@@ -43,14 +44,16 @@ Decoder::Decoder(int hd) {
 }
 
 bool Decoder::decode(const Codeword& c, int errCorr, int& id, int& shift) {
+  int bestError = INT_MAX;
   for (unsigned int i = 0; i < codewords.size(); i++) {
-    Codeword xorResult = c ^ codewords[i];  // XOR
+    const Codeword xorResult = c ^ codewords[i];  // XOR
+    const int error = xorResult.count();
 
-    if (xorResult.count() <= errCorr) {
+    if ((error <= errCorr) && (error < bestError)) {
       id = i % noOfCodewords;
       shift = i / noOfCodewords;
-      return true;
+      bestError = error;
     }
   }
-  return false;
+  return (bestError != INT_MAX);
 }


### PR DESCRIPTION
…from `Decoder::decoder()`.

We did observe some spurious detections of the wrong code, if multiple candidates are sufficiently close, depending on the value of `errorCorrection` passed to the `STag` constructor. Even for high values it may be desirable to return the candidate with the least amount of bit errors.

We are using this patch for a while now in our fork (Intermodalics/stag_ros#1), and the number of false detections has been reduced. What do you think?